### PR TITLE
CC #158 - Genres discover

### DIFF
--- a/app/controllers/concerns/api/searchable.rb
+++ b/app/controllers/concerns/api/searchable.rb
@@ -4,9 +4,22 @@ module Api::Searchable
   included do
     def self.search_attributes(*attrs)
       @attrs ||= []
-      attrs.each do |attr|
-        @attrs << "#{self.controller_name}.#{attr.to_s}" if attrs.present?
+
+      # Iterate over the attributes and add them for the list.
+      #
+      # For symbols, we'll assume that the column is on the primary table and use the controller name to format the SQL
+      # as <table-name>.<column_name>.
+      #
+      # For strings, we'll assume that the column is NOT on the primary table (instead possibly a join table) and
+      # allow the controller to format the SQL as appropriate.
+      attrs&.each do |attr|
+        if attr.is_a?(Symbol)
+          @attrs << "#{self.controller_name}.#{attr.to_s}"
+        elsif attr.is_a?(String)
+          @attrs << attr
+        end
       end
+
       @attrs
     end
 


### PR DESCRIPTION
This pull request updates the `searchable` controller concern to allow more flexibility with the names of the columns used for searching. Previously, the concern would always prepend the `controller_name` to the provided parameters. So if you had something like `search_attributes :name` in your `sources_controller`, the concern would add a query for `sources.name` to the SQL. This is great for the simple queries as it avoids ambiguity by prepending the table name and doesn't require the user to specify it in the implementing controller. 

I ran into an issue where I was using the concern in a `citations_controller` and wanted to search on a joined table called `sources` on the columns `searchable_name`. There was no way to do this as using `search_attributes 'sources.searchable_name'` resulted in the column `citations.sources.searchable_name`.

This change will treat the attributes provided to the `search_attributes` differently depending on type. Symbol parameters will function the same way as before, and prepend the `controller_name`. String parameters will be added as literals to allow for additional customization.

```
search_attributes :name, :description
```

```
search_attributes 'sources.name', 'sources.description'
```