### PR TITLE
EVQ #207 - Text view

### DIFF
--- a/app/controllers/api/resource_controller.rb
+++ b/app/controllers/api/resource_controller.rb
@@ -33,7 +33,7 @@ class Api::ResourceController < ActionController::API
     query = apply_filters(query)
     query = apply_sort(query)
 
-    list, items = pagy(query, items: params[:per_page] || self.class.per_page, page: params[:page])
+    list, items = pagy(query, items: per_page, page: params[:page])
     metadata = pagy_metadata(list)
 
     serializer = serializer_class.new(current_user)
@@ -153,5 +153,19 @@ class Api::ResourceController < ActionController::API
 
   def param_name
     controller_name.singularize
+  end
+
+  def per_page
+    # Default count to the provided parameter
+    count = params[:per_page].to_i if params.has_key?(:per_page) && params[:per_page].respond_to?(:to_i)
+
+    # Use the per_page defined in the controller if no parameter is provided
+    count = self.class.per_page if count.nil?
+
+    # If the count is less than zero, return all records. This will produce an extra query in order to obtain the count
+    # of the number of records.
+    return item_class.all.count if count <= 0
+
+    count
   end
 end


### PR DESCRIPTION
This pull request updates the `resource_controller` to allow passing a value <= `0` to return all results. This is useful in situations when records are returned from the API, but are not displayed in a paginated form.

The limit can be removed by setting the `per_page` attribute in the implementing controller. This method should be used if all of the calls to the API end point should not paginate results.

```ruby
class MyAwesomeController < Api::ResourceController
  per_page: 0

  ...
end
```

Or by passing a `per_page` parameter to the API. This method should be used if sometimes the results should be paginated, and sometimes they should not.

```javascript
MyAwesomeResource
  .fetchAll({ per_page: 0 })
  .then(({ data })) => ....)
```