### PR TITLE
BASIRA #88 - Boolean columns

### DIFF
--- a/app/models/concerns/resourceable.rb
+++ b/app/models/concerns/resourceable.rb
@@ -1,6 +1,24 @@
 module Resourceable
   extend ActiveSupport::Concern
 
+  included do
+    before_create :set_booleans
+
+    private
+
+    # Default any boolean columns to "false" if a value is not provided
+    def set_booleans
+      boolean_attributes = self
+                             .class.columns_hash
+                             .select{ |k,v| v.type == :boolean }
+                             .map{ |k, v| k }
+
+      boolean_attributes.each do |attribute|
+        self[attribute.to_sym] = false unless self[attribute.to_sym].present?
+      end
+    end
+  end
+
   class << self
     def included(base)
       base.extend ClassMethods


### PR DESCRIPTION
This pull request updates the `resourceable` concern to default any boolean attributes to "false" before a new record is created. When coming in from an API request, these values are often `undefined` or empty strings, resulting in an error at the database level when a new record is inserted.