### PR TITLE
EVQ #248 - Fix per_page bug when 0 records total

### DIFF
--- a/app/controllers/api/resource_controller.rb
+++ b/app/controllers/api/resource_controller.rb
@@ -170,9 +170,18 @@ class Api::ResourceController < ActionController::API
     # Use the per_page defined in the controller if no parameter is provided
     count = self.class.per_page if count.nil?
 
-    # If the count is less than zero, return all records. This will produce an extra query in order to obtain the count
+    # If the count is less than or equal to zero, return all records. 
+    # This will produce an extra query in order to obtain the count
     # of the number of records.
-    return item_class.all.count if count <= 0
+    if count <= 0
+      all_count = item_class.all.count
+      # Prevent per_page being set to 0 if there are 0 records
+      if all_count == 0
+        count = self.class.per_page
+      else
+        count = all_count
+      end
+    end
 
     count
   end


### PR DESCRIPTION
Fixes a bug that was exposed in https://github.com/artshumrc/evq/issues/248 when `params[:per_page]` was `0` and `item_class.all.count` was also `0`.