### PR TITLE
EVQ #248 - Principles

### DIFF
--- a/app/controllers/api/resource_controller.rb
+++ b/app/controllers/api/resource_controller.rb
@@ -119,9 +119,9 @@ class Api::ResourceController < ActionController::API
 
         attributes = parameters.delete(nested_attributes_param)
 
-        if attributes.is_a?(ActionController::Parameters)
-          parameters[nested_attributes] = attributes.keys.map do |key|
-            parameters[nested_attributes] = rename_params(attributes[key], permitted_parameter[nested_attributes])
+        if attributes.is_a?(Array)
+          parameters[nested_attributes] = attributes.map do |attrs|
+            parameters[nested_attributes] = rename_params(attrs, permitted_parameter[nested_attributes])
           end
         else
           parameters[nested_attributes] = attributes
@@ -170,7 +170,7 @@ class Api::ResourceController < ActionController::API
     # Use the per_page defined in the controller if no parameter is provided
     count = self.class.per_page if count.nil?
 
-    # If the count is less than or equal to zero, return all records. 
+    # If the count is less than or equal to zero, return all records.
     # This will produce an extra query in order to obtain the count
     # of the number of records.
     if count <= 0

--- a/app/controllers/api/resource_controller.rb
+++ b/app/controllers/api/resource_controller.rb
@@ -123,6 +123,10 @@ class Api::ResourceController < ActionController::API
           parameters[nested_attributes] = attributes.map do |attrs|
             parameters[nested_attributes] = rename_params(attrs, permitted_parameter[nested_attributes])
           end
+        elsif attributes.is_a?(ActionController::Parameters) && attributes.keys.all?(&:is_integer?)
+          parameters[nested_attributes] = attributes.keys.map do |key|
+            parameters[nested_attributes] = rename_params(attributes[key], permitted_parameter[nested_attributes])
+          end
         else
           parameters[nested_attributes] = attributes
         end

--- a/lib/extensions/string.rb
+++ b/lib/extensions/string.rb
@@ -1,4 +1,8 @@
 class String
+  def is_integer?
+    true if Integer(self) rescue false
+  end
+
   def to_bool
     return true if self == true || self =~ /^(true|t|yes|y|1)$/i
     false


### PR DESCRIPTION
This pull request fixes a bug in the resource_controller renaming nested attributes for a `has_one` relationship. The issue arises from how the payload serializes array differently for JSON vs. form data.

## JSON
```
base: {
  children: [{
    id: 1
    name: 'First'
  }, {
    id: 2,
    name: 'Second'
  }]
}
```

## Form Data
```
base: {
  children: {
    '0': {
      id: 1,
      name: 'First'
    },
    '1': {
      id: 2,
      name: 'Second'
    }
  }
}
```

Although it's an array, with form data, it's serialized as a hash with the indexes as keys. The solution was to add a new condition to `resource_controller#rename_params` to account for both situations and treat them as objects that can contain nested attributes.