### PR TITLE
RA #24 - Date filters

### DIFF
--- a/app/controllers/concerns/api/filterable.rb
+++ b/app/controllers/concerns/api/filterable.rb
@@ -74,6 +74,7 @@ module Api::Filterable
 
       start_date = DateTime.parse(date[:startDate])
       end_date = DateTime.parse(date[:endDate])
+      end_date = end_date + (23.hours + 59.minutes)
 
       query.where(attribute => start_date..end_date)
     end


### PR DESCRIPTION
This pull request fixes a bug with the date filters when the start date and end date values are the same. The query uses the PostgreSQL `BETWEEN` filter which is equivalent to:

```
WHERE date >= '2022-01-01'
  AND date <= '2022-01-01'
```

Since most dates will include a time component, it will almost aways fail the `<=` check. In this case, we'll add 23 hours, 59 minutes to the end date in order to include all dates which fall into that time range.