### PR TITLE
UDF #3 - Search/sort

### DIFF
--- a/app/controllers/api/resource_controller.rb
+++ b/app/controllers/api/resource_controller.rb
@@ -2,6 +2,7 @@ class Api::ResourceController < ActionController::API
   # Includes
   include Api::Queryable
   include Api::Searchable
+  include Api::Sortable
   include Pagy::Backend
 
   def create
@@ -32,6 +33,7 @@ class Api::ResourceController < ActionController::API
   def index
     query = base_query
     query = build_query(query)
+    query = apply_search(query)
     query = apply_filters(query)
     query = apply_sort(query)
 
@@ -84,6 +86,10 @@ class Api::ResourceController < ActionController::API
   end
 
   protected
+
+  def apply_filters(query)
+    query
+  end
 
   def base_query
     item_class.all
@@ -145,23 +151,6 @@ class Api::ResourceController < ActionController::API
   end
 
   private
-
-  def apply_filters(query)
-    apply_search(query)
-  end
-
-  def apply_sort(query)
-    return query unless params[:sort_by].present?
-
-    sort_bys = params[:sort_by].is_a?(Array) ? params[:sort_by] : [params[:sort_by]]
-    sort_direction = params[:sort_direction] == 'descending' ? :desc : :asc
-
-    sort_bys.each_with_index do |sort_by, index|
-      query = query.order(sort_by.to_sym => sort_direction)
-    end
-
-    query
-  end
 
   def param_name
     controller_name.singularize

--- a/app/controllers/concerns/api/sortable.rb
+++ b/app/controllers/concerns/api/sortable.rb
@@ -1,0 +1,34 @@
+module Api::Sortable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def sort_methods(*methods)
+      @sort_methods ||= []
+      @sort_methods += methods unless methods.nil?
+      @sort_methods
+    end
+  end
+
+  included do
+    def apply_sort(query)
+      [*self.class.sort_methods, :apply_default_sort].each do |method|
+        query = self.send(method, query)
+      end
+
+      query
+    end
+
+    def apply_default_sort(query)
+      return query if params[:sort_by].blank? || query.order_values.size > 0
+
+      sort_bys = params[:sort_by].is_a?(Array) ? params[:sort_by] : [params[:sort_by]]
+      sort_direction = params[:sort_direction] == 'descending' ? :desc : :asc
+
+      sort_bys.each do |sort_by|
+        query = query.order(sort_by.to_sym => sort_direction)
+      end
+
+      query
+    end
+  end
+end


### PR DESCRIPTION
This pull request refactors the way the `Api::Searchable` concern builds a query. Previously, when a user entered a search term, the query would be built by joining all of the specified `search_attributes` with a SQL `OR` clause. This worked fine until another concern needs to override the default functionality. And even more of a headache if multiple concerns need to implement different functionality. 

The following pseudo-code illustrates how the search will be applied:

```ruby
[:default_search, :concern_1, :concern_2, :concern_n].each do |search_implementation|
  query.or(search_implementation)
end
``` 

The refactoring will also provided methods that can be overridden to alter the default search functionality.

This pull request also creates the `Api::Sortable` concern, which allows multiple implementations of sorting functionality to be conditionally applied to the query in the same manner as the `Api::Searchable` concern.