### PR TITLE
UDCSL #212 - Annotations

### DIFF
--- a/app/controllers/api/resource_controller.rb
+++ b/app/controllers/api/resource_controller.rb
@@ -14,7 +14,7 @@ class Api::ResourceController < ActionController::API
       preloads(item)
 
       serializer = serializer_class.new(current_user)
-      render json: { param_name.to_sym => serializer.render_index(item) }
+      render json: { param_name.to_sym => serializer.render_show(item) }
     else
       render json: { errors: item.errors }, status: 400
     end
@@ -79,7 +79,7 @@ class Api::ResourceController < ActionController::API
       item_name = param_name.to_sym
       serializer = serializer_class.new(current_user)
 
-      render json: { item_name => serializer.render_index(item) }
+      render json: { item_name => serializer.render_show(item) }
     else
       render json: { errors: item.errors }, status: 400
     end


### PR DESCRIPTION
This pull request updates the `resource_controller` render the `show` attributes for the `create` and `update` methods. This way, the full version of the new record is returned from the API call. I believe the reason we made the change to return the `index` attributes was a work-around for Archnet. Some of the records were huge and returning the `show` attributes was causing a timeout. Ultimately I think that was an architectural issue within Archnet (which has since been corrected), not the fault of the `resource-api`.