### PR TITLE
CDC #13 - Setup

### DIFF
--- a/app/controllers/concerns/api/searchable.rb
+++ b/app/controllers/concerns/api/searchable.rb
@@ -34,7 +34,7 @@ module Api::Searchable
 
     def resolve_search_attribute(attr)
       if attr.is_a?(Symbol)
-        "#{self.class.controller_name}.#{attr.to_s}"
+        "#{item_class.table_name}.#{attr.to_s}"
       elsif attr.is_a?(String)
         attr
       end


### PR DESCRIPTION
This pull request updates the `resolve_search_attribute` method in the `searchable` concern to use the table name instead of the controller name to prefix query columns.