### PR TITLE
CDC #16 - User defined fields

### DIFF
--- a/app/controllers/concerns/api/searchable.rb
+++ b/app/controllers/concerns/api/searchable.rb
@@ -43,7 +43,11 @@ module Api::Searchable
     private
 
     def apply_searchable(query)
+      # No need to apply a search if no parameter is applied
       return query unless params[:search].present?
+
+      # No need to apply a search if no attributes are provided
+      return query if self.class.search_attributes.empty?
 
       or_query = nil
 
@@ -57,7 +61,11 @@ module Api::Searchable
         end
       end
 
-      query.merge(or_query)
+      if query == item_class.all
+        query.merge(or_query)
+      else
+        query.or(or_query)
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request fixes an issue in the `searchable` concern where an error was being thrown if no `search_attributes` were provided by the controller.

There was also an issue when the query provided was searching for all records, and being `or`'d with another query.