### PR TITLE
Fix for 'Is Empty' and 'Is Not Empty' filters in Filterable

### DIFF
--- a/app/controllers/concerns/api/filterable.rb
+++ b/app/controllers/concerns/api/filterable.rb
@@ -93,9 +93,9 @@ module Api::Filterable
       when OPERATOR_NOT_CONTAIN
         query.where.not("#{attribute} ILIKE ?", "%#{value}%")
       when OPERATOR_EMPTY
-        query.where(attribute.blank?)
+        query.where("#{attribute} = '' OR #{attribute} IS NULL" )
       when OPERATOR_NOT_EMPTY
-        query.where.not(attribute.blank?)
+        query.where("DATALENGTH#{attribute} > 0")
       when OPERATOR_GREATER_THAN
         query.where("#{attribute} > #{value}")
       when OPERATOR_LESS_THAN

--- a/app/controllers/concerns/api/filterable.rb
+++ b/app/controllers/concerns/api/filterable.rb
@@ -93,7 +93,7 @@ module Api::Filterable
       when OPERATOR_NOT_CONTAIN
         query.where.not("#{attribute} ILIKE ?", "%#{value}%")
       when OPERATOR_EMPTY
-        query.where(attribute => nil)
+        query.where(attribute.blank?)
       when OPERATOR_NOT_EMPTY
         query.where.not(attribute => nil)
       when OPERATOR_GREATER_THAN

--- a/app/controllers/concerns/api/filterable.rb
+++ b/app/controllers/concerns/api/filterable.rb
@@ -95,7 +95,7 @@ module Api::Filterable
       when OPERATOR_EMPTY
         query.where(attribute.blank?)
       when OPERATOR_NOT_EMPTY
-        query.where.not(attribute => nil)
+        query.where.not(attribute.blank?)
       when OPERATOR_GREATER_THAN
         query.where("#{attribute} > #{value}")
       when OPERATOR_LESS_THAN

--- a/app/controllers/concerns/api/filterable.rb
+++ b/app/controllers/concerns/api/filterable.rb
@@ -95,7 +95,7 @@ module Api::Filterable
       when OPERATOR_EMPTY
         query.where("#{attribute} = '' OR #{attribute} IS NULL" )
       when OPERATOR_NOT_EMPTY
-        query.where("DATALENGTH#{attribute} > 0")
+        query.where("#{attribute} IS NOT NULL AND #{attribute} != ''")
       when OPERATOR_GREATER_THAN
         query.where("#{attribute} > #{value}")
       when OPERATOR_LESS_THAN


### PR DESCRIPTION
## In this PR

When addressing https://github.com/performant-software/archnet3/issues/1019 it was determined that these filters were not working as expected. This fix check for NULL and empty strings.