### PR TITLE
CDC #237 - Image Uploads

### DIFF
--- a/app/controllers/concerns/api/uploadable.rb
+++ b/app/controllers/concerns/api/uploadable.rb
@@ -12,6 +12,7 @@ module Api::Uploadable
       begin
         item_class.transaction do
           items = item_class.create(upload_params)
+          errors = items.map(&:errors).delete_if(&:empty?)
         end
       rescue ActiveRecord::RecordInvalid => exception
         errors = [exception]


### PR DESCRIPTION
This pull request updates the `uploadable` concern to retrieve errors from the `create` method. Previously, if model validation errors occurred, the upload would look successful but silently fail.