### PR TITLE
Archnet #1112 - Empty Attachments

### DIFF
--- a/app/controllers/concerns/api/filterable.rb
+++ b/app/controllers/concerns/api/filterable.rb
@@ -74,7 +74,7 @@ module Api::Filterable
         subquery = belongs_to_query(filter)
       end
 
-      return query unless subquery.present?
+      return query if subquery.nil?
 
       attribute = filter[:attribute_name]
       value = filter[:value]


### PR DESCRIPTION
This pull request fixes a bug in the `filterable` concern using a `.present?` check which was causing the query to execute. The solution was to replace the check with `.nil?` to prevent the query from being executed.