### PR TITLE
CDC #275 - Non-deterministic sort

### DIFF
--- a/app/controllers/concerns/api/sortable.rb
+++ b/app/controllers/concerns/api/sortable.rb
@@ -15,6 +15,9 @@ module Api::Sortable
         query = self.send(method, query)
       end
 
+      # Always order records by ID last to avoid non-deterministic ordering
+      query = query.order(:id)
+
       query
     end
 


### PR DESCRIPTION
This pull request updates the `apply_sort` method in the `sortable` concern to always sort records lastly by `id` in order to avoid non-deterministic ordering when sorting by columns with non-unique values.