### PR TITLE
CDC #301 - Related Record Pagination

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -86,8 +86,8 @@
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/extras/overflow
-# require 'pagy/extras/overflow'
-# Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+require 'pagy/extras/overflow'
+Pagy::DEFAULT[:overflow] = :last_page    # default  (other options: :last_page and :exception)
 
 # Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
 # See https://ddnexus.github.io/pagy/extras/metadata


### PR DESCRIPTION
This pull request modifies the `pagy` installer to include an `overflow` value of 'last_page` to prevent errors when a client requests a page that is out of scope.