### PR TITLE
CDC #484 - Direct uploads

### DIFF
--- a/app/controllers/concerns/api/uploadable.rb
+++ b/app/controllers/concerns/api/uploadable.rb
@@ -20,7 +20,7 @@ module Api::Uploadable
 
       if errors.empty?
         serializer = serializer_class.new
-        render json: { controller_name.to_sym => items.map{ |i| serializer.render_index(i) } }, status: :ok
+        render json: { controller_name.to_sym => serializer.render_index(items) }, status: :ok
       else
         render json: { errors: errors }, status: 422
       end


### PR DESCRIPTION
This pull request fixes an issue in the `uploadable` concern to support [#484](https://github.com/performant-software/core-data-cloud/issues/484). There was a fix a while back to refactor the `render_index` method of the serializers to accept an array of items and return an array of serialized items. We must have missed this use of the method, which is still iterating over the items and calling `render_index`, resulting in the data being formatted as an array of arrays.