### PR TITLE
Add `prepare_items` method

### DIFF
--- a/app/controllers/api/resource_controller.rb
+++ b/app/controllers/api/resource_controller.rb
@@ -51,9 +51,15 @@ class Api::ResourceController < ActionController::API
     list, items = pagy(query, items: per_page, page: params[:page])
     metadata = pagy_metadata(list)
 
+    items = prepare_items(items)
+
     preloads(items)
 
     render json: build_index_response(items, metadata), status: :ok
+  end
+
+  def prepare_items(items)
+    items
   end
 
   def show


### PR DESCRIPTION
# Summary

This PR adds a new `prepare_items` method that child classes can override to make custom modifications to the SQL in the `index` method.